### PR TITLE
Update Python due to changes in fast-export script

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,15 +1,28 @@
-FROM python:2.7-alpine3.11
-# docker build --pull --no-cache -t bscheshir/hg-to-git:python2.7-alpine3.11 -- ./build && docker push bscheshir/hg-to-git:python2.7-alpine3.11
-# docker build --pull -t bscheshir/hg-to-git:python2.7-alpine3.11 -- ./build
-MAINTAINER BSCheshir <bscheshir.work@gmail.com>
+FROM python:3.9.18-alpine3.18
+# docker build --pull --no-cache -t bscheshir/hg-to-git:python3.9.18-alpine3.18 -- ./build && docker push bscheshir/hg-to-git:python3.9.18-alpine3.18
+# docker build --pull -t bscheshir/hg-to-git:python3.9.18-alpine3.18 -- ./build
+LABEL maintainer="BSCheshir <bscheshir.work@gmail.com>"
 
 RUN apk --update add \
         git \
         git-fast-import \
         bash \
         bash-completion
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev \
+RUN apk add --no-cache --virtual .build-deps \
+    gcc musl-dev \
     && pip install mercurial \
+    && find /usr/local \
+        \( -type d -a -name test -o -name tests \) \
+        -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+        -exec rm -rf '{}' + \
+    && runDeps="$( \
+        scanelf --needed --nobanner --recursive /usr/local \
+                | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+                | sort -u \
+                | xargs -r apk info --installed \
+                | sort -u \
+    )" \
+    && apk add --virtual .rundeps $runDeps \
     && apk del .build-deps
 
 # Prepare host-volume working directory

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 services:
   alpine:
     build: ./build
-#    image: bscheshir/hg-to-git:alpine3.11
+#    image: bscheshir/hg-to-git:3.9.18-alpine3.18
     volumes:
       - ./git-repo:/data/git-repo
       - ./hg-repo:/data/hg-repo


### PR DESCRIPTION
Python 2 has been removed from capatible environment of fast-export script. Some import not work on python2 now: https://github.com/frej/fast-export/commit/a3d0562737e1e711659e03264e45cb47a5a2f46d

https://github.com/frej/fast-export/commit/c49dd0cf60fb14d822314c2bb1daa24bd99fc3b6

Maybe put specific tag on clone function to avoid malfunction on commit in fast-export repo. (I wait newer tag of fast-export to pull request that).